### PR TITLE
Add popup hard return support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "LocalLayer",
   "label": "Local Layer Widget",
   "platform": "HTML",
-  "version": "1.2",
+  "version": "1.3",
   "wabVersion": "1.1",
   "author": "Adam Drackley (adam.drackley@gmail.com) & Robert Scheitlin",
   "description": "This widget is for adding local layer to Web AppBuilder",

--- a/setting/PopupEdit.js
+++ b/setting/PopupEdit.js
@@ -113,8 +113,8 @@ define(
         if(this.config.title){
           this.titleTextBox.set('value',this.config.title);
         }
-        if(this.config.content){
-          this.customContentTA.value = this.config.content;
+        if(this.config.description){
+          this.customContentTA.value = this.config.description;
           this.tabContainer.selectTab(this.wnls.custom);
         }
         if(this.flinfo){
@@ -291,7 +291,7 @@ define(
           }
         }));
         if(this.customContentTA.value && this.customContentTA.value.length > 0){
-          config.custom = this.customContentTA.value;
+          config.description = this.customContentTA.value.replace('\n', '<br>');
         }
         config.showAttachments = this.showAttachmentsCbx.getValue();
         config.tr = this.tr;
@@ -400,7 +400,7 @@ define(
         }
         this.popup.close();
         this.popupState = '';
-        this._wrapAroundSelection(this.customContentTA,'<a href="' + hyperlinkConfig.url + '">','</a>');
+        this._insertAtCursor(this.customContentTA,'<a href="' + hyperlinkConfig.url + '">'+ hyperlinkConfig.description + '</a>');
         this.customContentTA.selectionStart = this.customContentTA.value.length;
       },
 
@@ -449,7 +449,6 @@ define(
         this.popup.close();
         this.popupState = '';
         this._insertAtCursor(this.customContentTA,'<img src="' + imageConfig.url + '"/>');
-        //this.customContentTA.selectionStart = this.customContentTA.value.length;
       },
 
       _onImgEditClose: function() {


### PR DESCRIPTION
When you are in the popup UI dialog and in the custom tab and adding custom text and hit enter to force the cursor to the next line the TextArea will add a \n to the text. This update replaces that \n with a &lt;br&gt;
